### PR TITLE
Add employee import module

### DIFF
--- a/chao_quan_employee_import/README.rst
+++ b/chao_quan_employee_import/README.rst
@@ -1,0 +1,13 @@
+Chao Quan Employee Import
+=========================
+
+This module provides a simple wizard to import employees from a CSV file.
+
+The CSV file should contain the following columns:
+
+* ``name``
+* ``job_title``
+* ``work_phone``
+* ``work_email``
+
+After installing the module, go to **Employees** > **Import Employees** to upload your CSV file.

--- a/chao_quan_employee_import/__init__.py
+++ b/chao_quan_employee_import/__init__.py
@@ -1,0 +1,1 @@
+from . import wizards

--- a/chao_quan_employee_import/__manifest__.py
+++ b/chao_quan_employee_import/__manifest__.py
@@ -1,0 +1,13 @@
+{
+    'name': 'Chao Quan Employee Import',
+    'version': '16.0.1.0.0',
+    'summary': 'Import employees from CSV for Chao Quan restaurant',
+    'author': 'Chao Quan',
+    'depends': ['hr'],
+    'data': [
+        'security/ir.model.access.csv',
+        'views/employee_import_wizard_views.xml',
+    ],
+    'installable': True,
+    'application': False,
+}

--- a/chao_quan_employee_import/security/ir.model.access.csv
+++ b/chao_quan_employee_import/security/ir.model.access.csv
@@ -1,0 +1,2 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_chao_quan_employee_import_wizard,chao.quan.employee.import.wizard,model_chao_quan_employee_import_wizard,base.group_user,1,1,1,1

--- a/chao_quan_employee_import/views/employee_import_wizard_views.xml
+++ b/chao_quan_employee_import/views/employee_import_wizard_views.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="view_employee_import_wizard" model="ir.ui.view">
+        <field name="name">employee.import.wizard.form</field>
+        <field name="model">chao_quan.employee.import.wizard</field>
+        <field name="arch" type="xml">
+            <form string="Import Employees" enctype="multipart/form-data">
+                <group>
+                    <field name="data_file" filename="filename"/>
+                    <field name="filename" invisible="1"/>
+                </group>
+                <footer>
+                    <button string="Import" type="object" name="action_import" class="btn-primary"/>
+                    <button string="Cancel" class="btn-secondary" special="cancel"/>
+                </footer>
+            </form>
+        </field>
+    </record>
+
+    <record id="action_employee_import_wizard" model="ir.actions.act_window">
+        <field name="name">Import Employees</field>
+        <field name="res_model">chao_quan.employee.import.wizard</field>
+        <field name="view_mode">form</field>
+        <field name="target">new</field>
+    </record>
+
+    <menuitem id="menu_employee_import" name="Import Employees" parent="hr.menu_hr_root" action="action_employee_import_wizard"/>
+</odoo>

--- a/chao_quan_employee_import/wizards/__init__.py
+++ b/chao_quan_employee_import/wizards/__init__.py
@@ -1,0 +1,1 @@
+from . import employee_import_wizard

--- a/chao_quan_employee_import/wizards/employee_import_wizard.py
+++ b/chao_quan_employee_import/wizards/employee_import_wizard.py
@@ -1,0 +1,31 @@
+from odoo import models, fields, api
+import base64
+import csv
+from io import StringIO
+
+
+class EmployeeImportWizard(models.TransientModel):
+    _name = 'chao_quan.employee.import.wizard'
+    _description = 'Employee Import Wizard'
+
+    data_file = fields.Binary(string='CSV File', required=True)
+    filename = fields.Char(string='Filename')
+
+    def action_import(self):
+        self.ensure_one()
+        if not self.data_file:
+            return
+        file_content = base64.b64decode(self.data_file)
+        csv_data = file_content.decode('utf-8')
+        reader = csv.DictReader(StringIO(csv_data))
+        employees = []
+        for row in reader:
+            vals = {
+                'name': row.get('name'),
+                'work_phone': row.get('work_phone'),
+                'work_email': row.get('work_email'),
+                'job_title': row.get('job_title'),
+            }
+            employees.append(vals)
+        for vals in employees:
+            self.env['hr.employee'].create(vals)


### PR DESCRIPTION
## Summary
- add simple Odoo module `chao_quan_employee_import`
- provide wizard to upload employee CSV
- create menu entry under HR
- document usage

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68786cd282a8832c8982f66d2f5db67c

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a new module that allows users to import employee data from CSV files via a dedicated wizard accessible from the Employees menu.
  * Added a user interface for uploading CSV files and triggering the import process.
  * Provided documentation outlining CSV requirements and usage instructions.

* **Documentation**
  * Added a README file with details on how to use the employee import functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->